### PR TITLE
Add gatewayMerchantId support

### DIFF
--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -124,7 +124,7 @@ class AliquotPay
       'paymentMethodDetails' => build_payment_method_details
     }
 
-    if @protocol_version == 'ECv2'
+    if @protocol_version == :ECv2
       @cleartext_message.merge!(
         'gatewayMerchantId' => @gateway_merchant_id || 'SOME GATEWAY MERCHANT ID'
       )

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -18,7 +18,7 @@ class AliquotPay
   attr_accessor :signed_key, :signatures
   attr_accessor :key_expiration, :key_value
   attr_accessor :encrypted_message, :cleartext_message, :ephemeral_public_key, :tag
-  attr_accessor :message_expiration, :message_id, :payment_method, :payment_method_details
+  attr_accessor :message_expiration, :message_id, :payment_method, :payment_method_details, :gateway_merchant_id
   attr_accessor :pan, :expiration_month, :expiration_year, :auth_method
   attr_accessor :cryptogram, :eci_indicator
 
@@ -113,6 +113,7 @@ class AliquotPay
 
   def build_cleartext_message
     return @cleartext_message if @cleartext_message
+
     default_message_id = Base64.strict_encode64(OpenSSL::Random.random_bytes(24))
     default_message_expiration = ((Time.now.to_f + 60 * 5) * 1000).round.to_s
 
@@ -122,6 +123,14 @@ class AliquotPay
       'paymentMethod'        => @payment_method || 'CARD',
       'paymentMethodDetails' => build_payment_method_details
     }
+
+    if @protocol_version == 'ECv2'
+      @cleartext_message.merge!(
+        'gatewayMerchantId' => @gateway_merchant_id || 'SOME GATEWAY MERCHANT ID'
+      )
+    end
+
+    @cleartext_message
   end
 
   def build_signed_message


### PR DESCRIPTION
This PR relates to this PR in the aliquot repo: https://github.com/clearhaus/aliquot/pull/21

Google Pay docs demand that integrators verify the gatewayMerchantId value in the Encrypted Message payload.

The current implementation of AliquotPay doesn't support generating this field.

This PR aims to resolve this by enabling users to generate tokens with this field, which should make testing new integrations easier.