### PR TITLE
Support Ruby 3.1 and 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       matrix:
         version:
-          # - 2.3 # Debian Stretch
-          # - 2.5 # Debian Buster
-           - 2.7 # Debian Bullseye
-          # - 3.0 # Debian Bookworm
+          - 2.7
+          - 3.0
+          - 3.1
+          - 3.2
     steps:
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ jobs:
     strategy:
       matrix:
         version:
-          - 2.7
-          - 3.0
-          - 3.1
-          - 3.2
+          - '2.7'
+          - '3.0'
+          - '3.1'
+          - '3.2'
     steps:
       - uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-# Only for development
-gem 'aliquot', git: 'https://github.com/Verseth/aliquot.git', branch: 'allow-ruby31'
-

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 
 gemspec
+# Only for development
+gem 'aliquot', git: 'https://github.com/Verseth/aliquot.git', branch: 'allow-ruby31'
+

--- a/aliquot-pay.gemspec
+++ b/aliquot-pay.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files = Dir.glob('lib/**/*.rb')
 
   s.add_runtime_dependency 'hkdf',    '~> 0.3'
-  # s.add_runtime_dependency 'aliquot', '~> 2.1.1'
+  s.add_runtime_dependency 'aliquot', '~> 2.1'
 
   s.add_development_dependency 'rspec', '~> 3'
 end

--- a/aliquot-pay.gemspec
+++ b/aliquot-pay.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files = Dir.glob('lib/**/*.rb')
 
   s.add_runtime_dependency 'hkdf',    '~> 0.3'
-  s.add_runtime_dependency 'aliquot', '~> 2.1.1'
+  # s.add_runtime_dependency 'aliquot', '~> 2.1.1'
 
   s.add_development_dependency 'rspec', '~> 3'
 end

--- a/lib/aliquot-pay/util.rb
+++ b/lib/aliquot-pay/util.rb
@@ -4,7 +4,7 @@ require 'hkdf'
 class AliquotPay
   class Util
     def self.generate_ephemeral_key
-      OpenSSL::PKey::EC.new(AliquotPay::EC_CURVE).generate_key
+      OpenSSL::PKey::EC.generate(AliquotPay::EC_CURVE)
     end
 
     def self.generate_shared_secret(private_key, public_key)


### PR DESCRIPTION
Hi, this PR makes this gem functional on Ruby 3.1 and 3.2.

Aliquot's Ruby version has to be `< 3.1`, so I had to temporarily edit the Gemfile so that it points to a branch on my fork of `aliquot` that removes this limit.

This PR is related to a [PR](https://github.com/clearhaus/aliquot/pull/23) in the aliquot gem.