### PR TITLE
Remove method `eckey_to_public`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,17 +8,17 @@ jobs:
     strategy:
       matrix:
         version:
-          # - 2.3 # Debian Stretch
-          # - 2.5 # Debian Buster
-           - 2.7 # Debian Bullseye
-          # - 3.0 # Debian Bookworm
+          - 2.7
+          - 3.0
+          - 3.1
+          - 3.2
     steps:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.version }}
 
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Gems
         run: bundle install

--- a/aliquot-pay.gemspec
+++ b/aliquot-pay.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name     = 'aliquot-pay'
-  s.version  = '2.2.0'
+  s.version  = '3.0.0'
   s.author   = 'Clearhaus'
   s.email    = 'hello@clearhaus.com'
   s.summary  = 'Generates Google Pay test dummy tokens'

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -144,9 +144,7 @@ class AliquotPay
     return @signed_key if @signed_key
     ensure_intermediate_key
 
-    if @intermediate_key.private_key? || @intermediate_key.public_key?
-      public_key = @intermediate_key
-    else
+    if @intermediate_key.private_key? && @intermediate_key.public_key?
       fail 'Intermediate key must be public and private key'
     end
 

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -43,8 +43,6 @@ class AliquotPay
     }.to_json
   end
 
-  #private
-
   def sign(key, message)
     d = OpenSSL::Digest::SHA256.new
     def key.private?; private_key?; end

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -144,7 +144,7 @@ class AliquotPay
     return @signed_key if @signed_key
     ensure_intermediate_key
 
-    if @intermediate_key.private_key? && @intermediate_key.public_key?
+    if !@intermediate_key.private_key? && !@intermediate_key.public_key?
       fail 'Intermediate key must be public and private key'
     end
 

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -150,7 +150,7 @@ class AliquotPay
       fail 'Intermediate key must be public and private key'
     end
 
-    default_key_value      = Base64.strict_encode64(eckey_to_public(@intermediate_key))
+    default_key_value      = Base64.strict_encode64(@intermediate_key.to_der)
     default_key_expiration = "#{Time.now.to_i + 3600}000"
 
     @signed_key = {

--- a/lib/aliquot-pay/util.rb
+++ b/lib/aliquot-pay/util.rb
@@ -4,7 +4,7 @@ require 'hkdf'
 class AliquotPay
   class Util
     def self.generate_ephemeral_key
-      OpenSSL::PKey::EC.new(AliquotPay::EC_CURVE).generate_key
+      OpenSSL::PKey::EC.generate(AliquotPay::EC_CURVE)
     end
 
     def self.generate_shared_secret(private_key, public_key)


### PR DESCRIPTION
As part of our migration to Ruby 3.1 we need to ensure that this gem supports it.

The OpenSSL library has tightened the mutability on objects.

Supported Ruby versions should now be 2.7, 3.0, 3.1 and 3.2