### PR TITLE
Allow setting a root_key to generate tokens which can be verified

### DIFF
--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -25,8 +25,11 @@ class AliquotPay
   attr_accessor :recipient, :info, :root_key, :intermediate_key
   attr_writer   :recipient_id, :shared_secret, :token, :signed_key_string
 
-  def initialize(protocol_version = :ECv2)
+  def initialize(protocol_version = :ECv2, root_key = nil)
     @protocol_version = protocol_version
+    if root_key
+      @root_key = root_key
+    end
   end
 
   def token

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -61,7 +61,9 @@ class AliquotPay
 
   def sign(key, message)
     d = OpenSSL::Digest::SHA256.new
-    def key.private?; private_key?; end
+    def key.private?
+      private_key?
+    end
     Base64.strict_encode64(key.sign(d, message))
   end
 


### PR DESCRIPTION
Without a way to define a `root_key` it has not been possible to validate the
signature of a token outside of `aliquot-pay` or packages that use
`aliquot-pay`. Which means that it is unusable as a standalone token generator
unless you extract the key for each token. Since we don't have a way to supply
root keys for googlepay in our gateway on runtime that solution is not feasible.
To fix this, supplying a EC private key allow setting the key used for signing
messages which can be validated outside `aliquot-pay` later. Our use-case for
this would be to use it in a script like below and then sending that to an
instance of our gateway, which can use the _known_ cert to validate the token.

```sh
PRIVATE_KEY="-----BEGIN EC PRIVATE KEY-----\nYOUR KEY HERE\n-----END EC PRIVATE KEY-----\n"

FAKE_TOKEN=$(ruby -r ./aliquot-pay/lib/aliquot-pay -r erb -r json -e "\
key = OpenSSL::PKey::EC.new($PRIVATE_KEY)
ap = AliquotPay.new(:ECv1, key); \
json_token = ap.token.to_json; \
puts ERB::Util.url_encode(json_token) + \";\" + ERB::Util.url_encode(ap.shared_secret)"
)

URL_ENCODED_TOKEN=$(echo $FAKE_TOKEN | cut -d ';' -f 1)
URL_ENCODED_SHARED_KEY=$(echo -n $FAKE_TOKEN | cut -d ';' -f 2)

curl -s -u <API KEY>: \
	-X POST fake-gateway.example/authorizations \
	-H "Signature: $API_KEY RS256-hex $SIGNATURE" \
	-d "amount=$AMOUNT&currency=$CURRENCY&\
	googlepay[token]=$URL_ENDODED_TOKEN&\
	googlepay[shared_key]=$URL_ENCODED_SHARED_KEY&\
	googlepay[recipient_id]=$MERCHANT_ID"
```
