### PR TITLE
Make default expiration year dynamic

### DIFF
--- a/aliquot-pay.gemspec
+++ b/aliquot-pay.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name     = 'aliquot-pay'
-  s.version  = '3.0.0'
+  s.version  = '3.0.1'
   s.author   = 'Clearhaus'
   s.email    = 'hello@clearhaus.com'
   s.summary  = 'Generates Google Pay test dummy tokens'

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -91,7 +91,7 @@ class AliquotPay
     return @payment_method_details if @payment_method_details
     value = {
       'pan'             => @pan              || '4111111111111111',
-      'expirationYear'  => @expiration_year  || 2023,
+      'expirationYear'  => @expiration_year  || Time.now.year + 1,
       'expirationMonth' => @expiration_month || 12,
       'authMethod'      => @auth_method      || 'PAN_ONLY',
     }


### PR DESCRIPTION
Entering 2024 means we now have some failing specs in a project utilizing this gem, and I believe it's better to fix the issue at its source.