### PR TITLE
Bump version to 3.0.2

### DIFF
--- a/aliquot-pay.gemspec
+++ b/aliquot-pay.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name     = 'aliquot-pay'
-  s.version  = '3.0.1'
+  s.version  = '3.0.2'
   s.author   = 'Clearhaus'
   s.email    = 'hello@clearhaus.com'
   s.summary  = 'Generates Google Pay test dummy tokens'


### PR DESCRIPTION
This is for https://github.com/clearhaus/aliquot-pay/pull/14. Version 3.0.1 was already used for something else.