### PR TITLE
Rework tokens to resemble googles sample tokens and support tokenized payment method

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
+
+gem 'aliquot', :git => 'https://github.com/clearhaus/aliquot', :branch => 'support-ecv1-tokenized-tokens'
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
 
-
-gem 'aliquot', :git => 'https://github.com/clearhaus/aliquot', :branch => 'support-ecv1-tokenized-tokens'
 gemspec

--- a/aliquot-pay.gemspec
+++ b/aliquot-pay.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name     = 'aliquot-pay'
-  s.version  = '3.0.2'
+  s.version  = '4.0.0'
   s.author   = 'Clearhaus'
   s.email    = 'hello@clearhaus.com'
   s.summary  = 'Generates Google Pay test dummy tokens'
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files = Dir.glob('lib/**/*.rb')
 
   s.add_runtime_dependency 'hkdf',    '~> 0.3'
-  s.add_runtime_dependency 'aliquot', '~> 2.1'
+  s.add_runtime_dependency 'aliquot', '~> 3.0'
 
   s.add_development_dependency 'rspec', '~> 3'
 end

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -123,20 +123,19 @@ class AliquotPay
     value = {
       'expirationYear'  => @expiration_year  || Time.now.year + 1,
       'expirationMonth' => @expiration_month || 12,
+      'eciIndicator'  => @eci_indicator || '05'
     }
     if @protocol_version == :ECv1
         value.merge!(
           'dpan'          => @pan || '4111111111111111',
           'authMethod'    => @auth_method || '3DS',
-          '3dsCryptogram' => @cryptogram    || Base64.strict_encode64(OpenSSL::Random.random_bytes(20)),
-          'eciIndicator'  => @eci_indicator || '05'
+          '3dsCryptogram' => @cryptogram    || Base64.strict_encode64(OpenSSL::Random.random_bytes(20))
           )
       else
         value.merge!(
           'pan'          => @pan || '4111111111111111',
           'authMethod'    => @auth_method || 'CRYPTOGRAM_3DS',
-          'cryptogram'   => @cryptogram    || Base64.strict_encode64(OpenSSL::Random.random_bytes(20)),
-          'eciIndicator' => @eci_indicator || '05'
+          'cryptogram'   => @cryptogram    || Base64.strict_encode64(OpenSSL::Random.random_bytes(20))
         )
       end
   end

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -121,20 +121,19 @@ class AliquotPay
     value = {
       'expirationYear'  => @expiration_year  || Time.now.year + 1,
       'expirationMonth' => @expiration_month || 12,
+        'eciIndicator'  => @eci_indicator || '05'
     }
     if @protocol_version == :ECv1
       value.merge!(
         'dpan'          => @pan           || '4111111111111111',
         'authMethod'    => @auth_method   || '3DS',
-        '3dsCryptogram' => @cryptogram    || Base64.strict_encode64(OpenSSL::Random.random_bytes(20)),
-        'eciIndicator'  => @eci_indicator || '05'
+        '3dsCryptogram' => @cryptogram    || Base64.strict_encode64(OpenSSL::Random.random_bytes(20))
       )
     else
       value.merge!(
         'pan'          => @pan           || '4111111111111111',
         'authMethod'   => @auth_method   || 'CRYPTOGRAM_3DS',
-        'cryptogram'   => @cryptogram    || Base64.strict_encode64(OpenSSL::Random.random_bytes(20)),
-        'eciIndicator' => @eci_indicator || '05'
+        'cryptogram'   => @cryptogram    || Base64.strict_encode64(OpenSSL::Random.random_bytes(20))
       )
     end
   end

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -214,12 +214,14 @@ class AliquotPay
             ensure_intermediate_key
           end
 
-    signature_string = ['Google',
-                        recipient_id,
-                        @protocol_version.to_s,
-                        signed_message_string].map do |str|
-      [str.length].pack('V') + str
-    end.join
+    signature_elements = [
+      'Google',
+      recipient_id,
+      @protocol_version.to_s,
+      signed_message_string,
+    ]
+    
+    signature_string = signature_elements.map { |e| [e.length].pack('V') + e }.join
     @signature = sign(key, signature_string)
   end
 

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -25,11 +25,11 @@ class AliquotPay
   attr_accessor :recipient, :info, :root_key, :intermediate_key
   attr_writer   :recipient_id, :shared_secret, :token, :signed_key_string
 
-  def initialize(protocol_version = :ECv2, root_key = nil, type = :browser)
+  def initialize(protocol_version: :ECv2, root_key: nil, type: :browser)
     @protocol_version = protocol_version
     @type = type
     if type == :app
-      @auth_method = '3DS_CRYPTOGRAM'
+      @auth_method = 'CRYPTOGRAM_3DS'
       if @protocol_version == :ECv1
         @auth_method = '3DS'
         @payment_method = 'TOKENIZED_CARD'
@@ -77,7 +77,7 @@ class AliquotPay
     when :ECv2
       cipher = OpenSSL::Cipher::AES256.new(:CTR)
     else
-      raise StandardError, "Invalid protocol_version #{protocol_version}"
+      raise StandardError, "Invalid protocol_version #{@protocol_version}"
     end
 
     keys = AliquotPay::Util.derive_keys(eph.public_key.to_bn.to_s(2), ss, @info, @protocol_version)
@@ -141,7 +141,6 @@ class AliquotPay
       end
   end
 
-
   def build_cleartext_message
     return @cleartext_message if @cleartext_message
 
@@ -154,7 +153,6 @@ class AliquotPay
       'paymentMethod'        => @payment_method || 'CARD',
       'paymentMethodDetails' => build_payment_method_details
     }
-
 
     if @protocol_version == :ECv2
       @cleartext_message.merge!(

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -27,6 +27,7 @@ class AliquotPay
 
   def initialize(protocol_version: :ECv2, root_key: nil, type: :browser)
     @protocol_version = protocol_version
+    @root_key = root_key
     @type = type
     if type == :app
       @auth_method = 'CRYPTOGRAM_3DS'
@@ -36,9 +37,6 @@ class AliquotPay
       end
     end
 
-    if root_key
-      @root_key = root_key
-    end
   end
 
   def token

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -123,19 +123,19 @@ class AliquotPay
     value = {
       'expirationYear'  => @expiration_year  || Time.now.year + 1,
       'expirationMonth' => @expiration_month || 12,
-      'eciIndicator'  => @eci_indicator || '05'
+      'eciIndicator'    => @eci_indicator    || '05'
     }
     if @protocol_version == :ECv1
         value.merge!(
-          'dpan'          => @pan || '4111111111111111',
+          'dpan'          => @pan         || '4111111111111111',
           'authMethod'    => @auth_method || '3DS',
-          '3dsCryptogram' => @cryptogram    || Base64.strict_encode64(OpenSSL::Random.random_bytes(20))
+          '3dsCryptogram' => @cryptogram  || Base64.strict_encode64(OpenSSL::Random.random_bytes(20))
           )
       else
         value.merge!(
-          'pan'          => @pan || '4111111111111111',
-          'authMethod'    => @auth_method || 'CRYPTOGRAM_3DS',
-          'cryptogram'   => @cryptogram    || Base64.strict_encode64(OpenSSL::Random.random_bytes(20))
+          'pan'        => @pan         || '4111111111111111',
+          'authMethod' => @auth_method || 'CRYPTOGRAM_3DS',
+          'cryptogram' => @cryptogram  || Base64.strict_encode64(OpenSSL::Random.random_bytes(20))
         )
       end
   end

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -38,10 +38,10 @@ class AliquotPay
   def extract_root_signing_keys
     key = Base64.strict_encode64(ensure_root_key.to_der)
     {
-      'keys' => [
+      'keys' => [{
         'protocolVersion' => @protocol_version,
         'keyValue'        => key
-      ]
+      }]
     }.to_json
   end
 

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -19,7 +19,7 @@ class AliquotPay
   attr_accessor :key_expiration, :key_value
   attr_accessor :encrypted_message, :cleartext_message, :ephemeral_public_key, :tag
   attr_accessor :message_expiration, :message_id, :payment_method, :payment_method_details, :gateway_merchant_id
-  attr_accessor :pan, :dpan, :expiration_month, :expiration_year, :auth_method
+  attr_accessor :pan, :expiration_month, :expiration_year, :auth_method
   attr_accessor :cryptogram, :eci_indicator
 
   attr_accessor :recipient, :info, :root_key, :intermediate_key

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -36,7 +36,6 @@ class AliquotPay
         @payment_method = 'TOKENIZED_CARD'
       end
     end
-
   end
 
   def token

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -19,7 +19,7 @@ class AliquotPay
   attr_accessor :key_expiration, :key_value
   attr_accessor :encrypted_message, :cleartext_message, :ephemeral_public_key, :tag
   attr_accessor :message_expiration, :message_id, :payment_method, :payment_method_details, :gateway_merchant_id
-  attr_accessor :pan, :expiration_month, :expiration_year, :auth_method
+  attr_accessor :pan, :dpan, :expiration_month, :expiration_year, :auth_method
   attr_accessor :cryptogram, :eci_indicator
 
   attr_accessor :recipient, :info, :root_key, :intermediate_key

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -127,12 +127,14 @@ class AliquotPay
     if @protocol_version == :ECv1
         value.merge!(
           'dpan'          => @pan || '4111111111111111',
+          'authMethod'    => @auth_method || '3DS',
           '3dsCryptogram' => @cryptogram    || Base64.strict_encode64(OpenSSL::Random.random_bytes(20)),
           'eciIndicator'  => @eci_indicator || '05'
           )
       else
         value.merge!(
           'pan'          => @pan || '4111111111111111',
+          'authMethod'    => @auth_method || 'CRYPTOGRAM_3DS',
           'cryptogram'   => @cryptogram    || Base64.strict_encode64(OpenSSL::Random.random_bytes(20)),
           'eciIndicator' => @eci_indicator || '05'
         )

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -113,19 +113,19 @@ class AliquotPay
     value = {
       'expirationYear'  => @expiration_year  || Time.now.year + 1,
       'expirationMonth' => @expiration_month || 12,
-      'eciIndicator'  => @eci_indicator || '05'
+      'eciIndicator'    => @eci_indicator    || '05'
     }
     if @protocol_version == :ECv1
       value.merge!(
-        'dpan'          => @pan           || '4111111111111111',
-        'authMethod'    => @auth_method   || '3DS',
-        '3dsCryptogram' => @cryptogram    || Base64.strict_encode64(OpenSSL::Random.random_bytes(20))
+        'dpan'          => @pan         || '4111111111111111',
+        'authMethod'    => @auth_method || '3DS',
+        '3dsCryptogram' => @cryptogram  || Base64.strict_encode64(OpenSSL::Random.random_bytes(20))
       )
     else
       value.merge!(
-        'pan'          => @pan           || '4111111111111111',
-        'authMethod'   => @auth_method   || 'CRYPTOGRAM_3DS',
-        'cryptogram'   => @cryptogram    || Base64.strict_encode64(OpenSSL::Random.random_bytes(20))
+        'pan'        => @pan         || '4111111111111111',
+        'authMethod' => @auth_method || 'CRYPTOGRAM_3DS',
+        'cryptogram' => @cryptogram  || Base64.strict_encode64(OpenSSL::Random.random_bytes(20))
       )
     end
   end

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -25,7 +25,7 @@ class AliquotPay
   attr_accessor :recipient, :info, :root_key, :intermediate_key
   attr_writer   :recipient_id, :shared_secret, :token, :signed_key_string
 
-  def initialize(protocol_version = :ECv2, type = :browser, root_key = nil)
+  def initialize(protocol_version = :ECv2, root_key = nil, type = :browser)
     @protocol_version = protocol_version
     @type = type
     if type == :app

--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -175,7 +175,7 @@ class AliquotPay
   end
 
   def signed_message_string
-    @signed_message_string ||= build_signed_message.to_json
+    build_signed_message.to_json
   end
 
   def build_signed_key

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -91,7 +91,6 @@ describe AliquotPay do
     end
   end
 
-
   context :ECv2 do
     context 'non-tokenized' do
       let(:instance) { AliquotPay.new(protocol_version: :ECv2, type: :browser) }

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -113,7 +113,5 @@ describe AliquotPay do
         expect(result.success?).to be(true), result.errors.to_s
       end
     end
-
-
   end
 end

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -3,7 +3,6 @@ require 'aliquot-pay'
 require 'json'
 require 'base64'
 
-
 shared_examples 'generation tests' do
   context 'encrypted_message' do
     let(:message) { instance.build_cleartext_message }

--- a/spec/generator_spec.rb
+++ b/spec/generator_spec.rb
@@ -3,24 +3,11 @@ require 'aliquot-pay'
 require 'json'
 require 'base64'
 
+
 shared_examples 'generation tests' do
-  context 'payment-payment_method_details' do
-    let(:details) { instance.build_payment_method_details }
-    let(:result)  { Aliquot::Validator::PaymentMethodDetailsSchema.call(details) }
-
-    it 'validates when PAN_ONLY' do
-      expect(result.success?).to be(true), result.errors.to_s
-    end
-
-    it 'validates when CRYPTOGRAM_3DS' do
-      instance.auth_method = 'CRYPTOGRAM_3DS'
-      expect(result.success?).to be(true), result.errors.to_s
-    end
-  end
-
   context 'encrypted_message' do
-    let(:message)  { instance.build_cleartext_message }
-    let(:result)   { Aliquot::Validator::EncryptedMessageSchema.call(message) }
+    let(:message) { instance.build_cleartext_message }
+    let(:result) { Aliquot::Validator::EncryptedMessageContract.schema.call(message) }
 
     it 'validates' do
       expect(result.success?).to be(true), result.errors.to_s
@@ -28,8 +15,8 @@ shared_examples 'generation tests' do
   end
 
   context 'signed_message' do
-    let(:message)  { instance.build_signed_message }
-    let(:result)   { Aliquot::Validator::SignedMessageSchema.call(message) }
+    let(:message) { instance.build_signed_message }
+    let(:result) { Aliquot::Validator::SignedMessageContract.schema.call(message) }
 
     it 'validates' do
       expect(result.success?).to be(true), result.errors.to_s
@@ -37,8 +24,8 @@ shared_examples 'generation tests' do
   end
 
   context 'token' do
-    let(:token)  { instance.token }
-    let(:result)   { Aliquot::Validator::TokenSchema.call(token) }
+    let(:token) { instance.token }
+    let(:result) { Aliquot::Validator::TokenContract.schema.call(token) }
 
     it 'validates' do
       expect(result.success?).to be(true), result.errors.to_s
@@ -55,35 +42,80 @@ shared_examples 'generation tests' do
   end
 end
 
-describe AliquotPay do
-  context :ECv1 do
-    let(:instance)     { AliquotPay.new(:ECv1) }
-    include_examples 'generation tests'
-
-    it 'has the correct protocolVersion' do
-      expect(instance.token['protocolVersion']).to eq('ECv1')
-    end
-
-    it 'excludes intermediateSigningKey' do
-      expect(instance.token['intermediateSigningKey']).to be nil
-    end
+shared_examples 'ECv1' do
+  it 'has the correct protocolVersion' do
+    expect(instance.token['protocolVersion']).to eq('ECv1')
   end
 
-  context :ECv2 do
-    let(:instance)     { AliquotPay.new(:ECv2) }
-    include_examples 'generation tests'
+  it 'excludes intermediateSigningKey' do
+    expect(instance.token['intermediateSigningKey']).to be nil
+  end
 
-    context 'signed_key' do
-      let(:message)  { instance.build_signed_key }
-      let(:result)   { Aliquot::Validator::SignedKeySchema.call(message) }
+end
 
-      it 'validates' do
-        expect(result.success?).to be(true), result.errors.to_s
-      end
+shared_examples 'ECv2' do
+  context 'signed_key' do
+    let(:message) { instance.build_signed_key }
+    let(:result) { Aliquot::Validator::SignedKeyContract.schema.call(message) }
+
+    it 'validates' do
+      expect(result.success?).to be(true), result.errors.to_s
     end
 
     it 'has the correct protocolVersion' do
       expect(instance.token['protocolVersion']).to eq('ECv2')
     end
+  end
+end
+
+describe AliquotPay do
+  context :ECv1 do
+    context 'non-tokenized' do
+      let(:instance) { AliquotPay.new(protocol_version: :ECv1, type: :browser) }
+      let(:details) { instance.build_payment_method_details }
+      include_examples 'generation tests'
+      it 'validates when type is browser' do
+        result = Aliquot::Validator::ECv1_PaymentMethodDetailsContract.schema.call(details)
+        expect(result.success?).to be(true), result.errors.to_s
+      end
+    end
+
+    context 'tokenized' do
+      let(:instance) { AliquotPay.new(protocol_version: :ECv1, type: :app) }
+      let(:details) { instance.build_payment_method_details }
+      include_examples 'generation tests'
+      it 'validates when type is app' do
+        details.merge!('threedsCryptogram' => details.delete('3dsCryptogram'))
+        result = Aliquot::Validator::ECv1_TokenizedPaymentMethodDetailsContract.schema.call(details)
+        expect(result.success?).to be(true), result.errors.to_s
+      end
+    end
+  end
+
+
+  context :ECv2 do
+    context 'non-tokenized' do
+      let(:instance) { AliquotPay.new(protocol_version: :ECv2, type: :browser) }
+      let(:details) { instance.build_payment_method_details }
+      let(:result)  { Aliquot::Validator::ECv2_PaymentMethodDetailsContract.schema.call(details) }
+      include_examples 'generation tests'
+      include_examples 'ECv2'
+      it 'validates when browser' do
+        expect(result.success?).to be(true), result.errors.to_s
+      end
+    end
+
+    context 'tokenized' do
+      let(:instance) { AliquotPay.new(protocol_version: :ECv2, type: :app) }
+      let(:details) { instance.build_payment_method_details }
+      let(:result)  { Aliquot::Validator::ECv2_TokenizedPaymentMethodDetailsContract.schema.call(details) }
+      include_examples 'generation tests'
+      include_examples 'ECv2'
+      it 'validates when CRYPTOGRAM_3DS' do
+        expect(result.success?).to be(true), result.errors.to_s
+      end
+    end
+
+
   end
 end


### PR DESCRIPTION
Previously `aliquot-pay` have only supported the `PAN_ONLY` payment method unless you assigned the `auth_method=` before generating but after creating the token. Even then the token would only be partially correct for `ECv2` and incorrect for `ECv1`. This have been reworked in order to support tokenized tokens.

https://developers.google.com/pay/api/processors/guides/test-and-validation/sample-tokens#ecv1