### PR TITLE
Fix payment menthod not getting set correctly

### DIFF
--- a/lib/aliquot-pay.rb
+++ b/lib/aliquot-pay.rb
@@ -29,6 +29,13 @@ class AliquotPay
     @protocol_version = protocol_version
     @root_key = root_key
     @type = type
+    if @type == :app
+      @auth_method = 'CRYPTOGRAM_3DS'
+      if @protocol_version == :ECv1
+        @auth_method = '3DS'
+        @payment_method = 'TOKENIZED_CARD'
+      end
+    end
   end
 
   def token
@@ -229,14 +236,6 @@ class AliquotPay
 
   def build_token
     return @token if @token
-
-    if @type == :app
-      @auth_method = 'CRYPTOGRAM_3DS'
-      if @protocol_version == :ECv1
-        @auth_method = '3DS'
-        @payment_method = 'TOKENIZED_CARD'
-      end
-    end
 
     res = {
       'protocolVersion' => @protocol_version.to_s,


### PR DESCRIPTION
Tests are failing on https://github.com/clearhaus/aliquot/actions/runs/7871391182/job/21474592619 because of https://github.com/clearhaus/aliquot-pay/pull/16/commits/df53b11f6e5b2f1715d4f21759b17821926b9ee6

The change means that the `payment_method` does not get set correctly and defaults to `CARD` for `ECv1` and `:app`. That causes tests to fail in `aliquot`